### PR TITLE
Reduce stickiness when wheel is inside a ScrollView

### DIFF
--- a/library/src/antistatic/spinnerwheel/AbstractWheel.java
+++ b/library/src/antistatic/spinnerwheel/AbstractWheel.java
@@ -854,6 +854,7 @@ public abstract class AbstractWheel extends View {
         }
 
         switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN: 
             case MotionEvent.ACTION_MOVE:
                 if (getParent() != null) {
                     getParent().requestDisallowInterceptTouchEvent(true);


### PR DESCRIPTION
The vertical wheel wasn't working properly when it was inside a
ScrollView. This fixes it from getting stuck.
