### PR TITLE
Build clean AAR

### DIFF
--- a/demo/src/main/res/layout/repopulating_data.xml
+++ b/demo/src/main/res/layout/repopulating_data.xml
@@ -16,7 +16,7 @@
                 android:textSize="20sp"
                 android:text="Please select the country"/>
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        <LinearLayout
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:gravity="center"

--- a/demo/src/main/res/layout/time_picker_custom.xml
+++ b/demo/src/main/res/layout/time_picker_custom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res/antistatic.spinnerwheel.demo"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_height="match_parent"
                 android:layout_width="match_parent"
         >

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 apply plugin: 'android-maven'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
+    provided files('libs/nineoldandroids-2.2.0.jar')
 }
 
 android {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,4 +8,8 @@ dependencies {
 android {
     compileSdkVersion 19
     buildToolsVersion "19.1.0"
+
+    defaultConfig {
+        minSdkVersion 3
+    }
 }


### PR DESCRIPTION
I've done some fixes to let project build in recent android SDK (some things was deprecated or not allowed anymore).

I also set nineoldandroids as provided to prevent double include when using another library. My suggestion is to remove it, if possible